### PR TITLE
Updated API service to use NY Times Top Stories API for fetching news articles...

### DIFF
--- a/app/src/main/java/com/example/newsmobileapplication/data/api/NewsApiService.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/data/api/NewsApiService.kt
@@ -3,15 +3,14 @@ package com.example.newsmobileapplication.data.api
 import com.example.newsmobileapplication.model.entities.NewsResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface NewsApiService {
-    @GET("v2/everything")
-    suspend fun getNews(
-        @Query("domains") domains: String = "bbc.com,cnn.com",
-        @Query("from") from: String,       // Son 24 saat için haberler
-        @Query("pageSize") pageSize: Int = 50,  // 50 haber çekmek için
-        @Query("page") page: Int = 1,
-        @Query("apiKey") apiKey: String = "ce8ab07efffa440aa8807379dd5042ca"
+
+    @GET("svc/topstories/v2/{section}.json")
+    suspend fun getTopStories(
+        @Path("section") section: String,
+        @Query("api-key") apiKey: String = "92ZIMgWcxwAnfmnZpRDAZtfzclRPWgyO"
     ): Response<NewsResponse>
 }

--- a/app/src/main/java/com/example/newsmobileapplication/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/di/module/NetworkModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    private const val BASE_URL = "https://newsapi.org/"
+    private const val BASE_URL = "https://api.nytimes.com/"
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/newsmobileapplication/model/entities/NewsItem.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/model/entities/NewsItem.kt
@@ -1,23 +1,29 @@
 package com.example.newsmobileapplication.model.entities
 
-
 data class NewsItem(
-    val title: String,
-    val description: String?,
-    val urlToImage: String?,
-    val content: String?,
-    val author: String?,
-    val publishedAt: String,
-    val id: String // ID must be provided
+    val title: String,                // Article title
+    val abstract: String?,            // Summary/description of the article (NY Times uses 'abstract')
+    val byline: String?,              // Author of the article
+    val published_date: String,       // Published date of the article
+    val url: String,                  // URL of the article
+    val multimedia: List<Multimedia>?,// List of multimedia (images)
+    val id: String                    // Generated unique ID
 )
 
 data class NewsResponse(
-    val status: String,
-    val totalResults: Int,
-    val articles: List<NewsItem>
+    val status: String,               // Status of the response
+    val section: String,              // The section of the articles (e.g. 'technology')
+    val num_results: Int,             // Number of results returned
+    val results: List<NewsItem>       // List of articles
 )
 
-data class Source(
-    val id: String?,
-    val name: String
+data class Multimedia(
+    val url: String?,                 // URL of the multimedia (image)
+    val format: String?,              // Format/type of multimedia (e.g. 'Standard Thumbnail')
+    val height: Int?,                 // Height of the image
+    val width: Int?,                  // Width of the image
+    val type: String?,                // Type of media (e.g. image)
+    val subtype: String?,             // Subtype of media (e.g. photo)
+    val caption: String?,             // Caption of the multimedia
+    val copyright: String?            // Copyright information
 )

--- a/app/src/main/java/com/example/newsmobileapplication/model/repository/FeedRepository.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/model/repository/FeedRepository.kt
@@ -1,5 +1,6 @@
 package com.example.newsmobileapplication.model.repository
 
+import android.util.Log
 import com.example.newsmobileapplication.data.api.NewsApiService
 import com.example.newsmobileapplication.model.entities.NewsItem
 import javax.inject.Inject
@@ -7,12 +8,14 @@ import javax.inject.Inject
 class FeedRepository @Inject constructor(
     private val apiService: NewsApiService
 ) {
-    suspend fun getNews(from: String): List<NewsItem>? {
-        val response = apiService.getNews(from = from)
-        return if (response.isSuccessful) {
-            response.body()?.articles
+    suspend fun getNews(section: String): List<NewsItem>? {
+        val response = apiService.getTopStories(section = section)
+        if (response.isSuccessful) {
+            Log.d("FeedRepository", "API Response: ${response.body()?.results}")
+            return response.body()?.results?.take(10) // İlk 10 haberi alıyoruz
         } else {
-            null
+            Log.e("FeedRepository", "API call failed: ${response.errorBody()?.string()}")
+            return null
         }
     }
 }

--- a/app/src/main/java/com/example/newsmobileapplication/ui/components/FavoriteCardComponent.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/components/FavoriteCardComponent.kt
@@ -90,7 +90,7 @@ fun FavoriteCardComponent(
                 text = newsContent,
                 fontSize = 14.sp,
                 color = Color.Gray,
-                maxLines = 3,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/example/newsmobileapplication/ui/components/NewsCardComponent.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/components/NewsCardComponent.kt
@@ -71,7 +71,7 @@ fun NewsCardComponent(
                 text = newsSummary,
                 fontSize = 14.sp,
                 color = Color.Gray,
-                maxLines = 3,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/app/src/main/java/com/example/newsmobileapplication/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/screens/DetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.rememberImagePainter
 import com.example.newsmobileapplication.viewmodel.FeedViewModel
+
 @Composable
 fun NewsDetailScreen(
     navController: NavController,
@@ -44,7 +45,6 @@ fun NewsDetailScreen(
     val isFavorite = remember { mutableStateOf(viewModel.isFavorite(newsItemId)) }
 
     if (newsItem == null) {
-        // Show a loading or error message if newsItem is null
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
@@ -52,18 +52,23 @@ fun NewsDetailScreen(
             Text(text = "Loading news details...", color = Color.Gray, fontSize = 18.sp)
         }
     } else {
-        // Display the news item details as before
-        Box(modifier = Modifier.fillMaxSize()) {
-            Image(
-                painter = rememberImagePainter(data = newsItem.urlToImage),
-                contentDescription = "News Image",
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer { alpha = 0.8f },
-                contentScale = ContentScale.Crop
-            )
+        // Feed ekranındaki gibi görseli multimedia'dan alalım
+        val newsImageUrl = newsItem.multimedia?.firstOrNull()?.url
 
-            // Back button
+        // Detay ekranını oluşturuyoruz
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (newsImageUrl!!.isNotEmpty()) {
+                Image(
+                    painter = rememberImagePainter(data = newsImageUrl),
+                    contentDescription = "News Image",
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = 0.8f },
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            // Geri butonu
             IconButton(
                 onClick = { navController.popBackStack() },
                 modifier = Modifier
@@ -75,7 +80,7 @@ fun NewsDetailScreen(
                 Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.Black)
             }
 
-            // Favorite button
+            // Favorilere ekleme butonu
             IconButton(
                 onClick = {
                     viewModel.toggleFavorite(newsItemId)
@@ -83,7 +88,7 @@ fun NewsDetailScreen(
                 },
                 modifier = Modifier
                     .padding(16.dp)
-                    .align(Alignment.TopEnd)  // Position it to the top right
+                    .align(Alignment.TopEnd)
                     .background(Color.White.copy(alpha = 0.6f), shape = RoundedCornerShape(50))
                     .size(40.dp)
             ) {
@@ -94,7 +99,7 @@ fun NewsDetailScreen(
                 )
             }
 
-            // Card for the news details
+            // Haber detaylarının bulunduğu kart
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -104,7 +109,7 @@ fun NewsDetailScreen(
             ) {
                 LazyColumn(modifier = Modifier.padding(16.dp)) {
                     item {
-                        // Title of the news
+                        // Haber başlığı
                         Text(
                             text = newsItem.title,
                             fontSize = 20.sp,
@@ -113,19 +118,28 @@ fun NewsDetailScreen(
                         )
                         Spacer(modifier = Modifier.height(8.dp))
 
-                        // Author
+                        // Yazar bilgisi
                         Text(
-                            text = "By ${newsItem.author ?: "Unknown author"}",
+                            text = "By ${newsItem.byline ?: "Unknown author"}",
                             fontSize = 14.sp,
                             color = Color.Gray
                         )
                         Spacer(modifier = Modifier.height(16.dp))
 
-                        // Content of the news (no maxLines limitation)
+                        // Haber özeti (abstract)
                         Text(
-                            text = newsItem.content ?: "No content available",
+                            text = newsItem.abstract ?: "No summary available",
                             fontSize = 16.sp,
                             color = Color.Black
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        // Haber detaylarına gitmek için URL
+                        Text(
+                            text = "Read more: ${newsItem.url}",
+                            fontSize = 14.sp,
+                            color = Color.Blue
                         )
                     }
                 }

--- a/app/src/main/java/com/example/newsmobileapplication/ui/screens/FavoriteScreen.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/screens/FavoriteScreen.kt
@@ -14,10 +14,13 @@ fun FavoriteScreen(navController: NavController, viewModel: FeedViewModel = hilt
 
     LazyColumn {
         items(favoriteNewsItems) { newsItem ->
+            // multimedia listesinden ilk görseli alıyoruz
+            val imageUrl = newsItem.multimedia?.firstOrNull()?.url
+
             FavoriteCardComponent(
                 newsTitle = newsItem.title,
-                newsContent = newsItem.content ?: "No content available",
-                newsImageUrl = newsItem.urlToImage ?: "",
+                newsContent = newsItem.abstract ?: "No content available",  // abstract alanı kullanılıyor
+                newsImageUrl = imageUrl ?: "",  // multimedia listesindeki görseli kullan
                 onClick = {
                     // Habere tıklayınca detay sayfasına gitme işlemi
                     navController.navigate("newsDetail/${newsItem.id}")

--- a/app/src/main/java/com/example/newsmobileapplication/ui/screens/FeedScreen.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/screens/FeedScreen.kt
@@ -12,6 +12,7 @@ import com.example.newsmobileapplication.ui.components.NewsCardComponent
 import com.example.newsmobileapplication.utils.generateNewsItemId
 import com.example.newsmobileapplication.viewmodel.FeedViewModel
 
+
 @Composable
 fun FeedScreen(navController: NavController, viewModel: FeedViewModel = hiltViewModel()) {
     val newsItems by viewModel.newsItems.collectAsState()
@@ -19,13 +20,18 @@ fun FeedScreen(navController: NavController, viewModel: FeedViewModel = hiltView
     LazyColumn {
         if (newsItems != null) {
             items(newsItems!!) { newsItem ->
-                val newsItemId = generateNewsItemId(newsItem.title, newsItem.publishedAt)
+                // Haberlerin URL'sine göre benzersiz bir ID oluşturuyoruz
+                val newsItemId = generateNewsItemId(newsItem.url)
+
+                // İlk görseli almak için multimedia listesini kontrol edin
+                val newsImageUrl = newsItem.multimedia?.firstOrNull()?.url ?: ""
+
                 NewsCardComponent(
                     newsTitle = newsItem.title,
-                    newsSummary = newsItem.description ?: "No summary available",
-                    newsImageUrl = newsItem.urlToImage ?: "",
+                    newsSummary = newsItem.abstract ?: "No summary available", // 'abstract' özeti temsil ediyor
+                    newsImageUrl = newsImageUrl, // İlk görselin URL'si alınıyor
                     onClick = {
-                        // Navigate to NewsDetailScreen with the generated ID
+                        // Haber detay sayfasına URL üzerinden yönlendirme yapıyoruz
                         navController.navigate("newsDetail/$newsItemId")
                     }
                 )

--- a/app/src/main/java/com/example/newsmobileapplication/utils/generateNewsItemId.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/utils/generateNewsItemId.kt
@@ -1,6 +1,6 @@
 package com.example.newsmobileapplication.utils
 
-fun generateNewsItemId(title: String, publishedAt: String): String {
-    return title.hashCode().toString() + publishedAt.hashCode().toString()
+// Fonksiyonu sadece String parametresi alacak şekilde güncelliyoruz
+fun generateNewsItemId(url: String): String {
+    return url.hashCode().toString()
 }
-


### PR DESCRIPTION
...
- Replaced the old API with the NY Times Top Stories API
- Modified the Retrofit service interface to call the new endpoint: '/svc/topstories/v2/{section}.json'
- Updated repository layer to fetch top stories from the selected section
- Adjusted the FeedViewModel to support the new API structure
- Updated the data models to match the new API response format, including fields like 'title', 'abstract', 'url', and 'multimedia'
- Applied appropriate error handling for missing sections or API key issues
- Limited the number of articles fetched to 10
- Tested the integration and ensured that news articles, including multimedia (images), are displayed correctly in both Feed and Detail screens