### PR TITLE
feat: Add Feed Screen layout with Breaking News and Recommendations

### DIFF
--- a/app/src/main/java/com/example/newsmobileapplication/model/repository/FeedRepository.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/model/repository/FeedRepository.kt
@@ -12,7 +12,7 @@ class FeedRepository @Inject constructor(
         val response = apiService.getTopStories(section = section)
         if (response.isSuccessful) {
             Log.d("FeedRepository", "API Response: ${response.body()?.results}")
-            return response.body()?.results?.take(5) // İlk 10 haberi alıyoruz
+            return response.body()?.results?.take(50) // İlk 10 haberi alıyoruz
         } else {
             Log.e("FeedRepository", "API call failed: ${response.errorBody()?.string()}")
             return null

--- a/app/src/main/java/com/example/newsmobileapplication/ui/components/NewsCardComponent.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/components/NewsCardComponent.kt
@@ -1,7 +1,6 @@
 package com.example.newsmobileapplication.ui.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -10,10 +9,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -25,8 +24,9 @@ import com.example.newsmobileapplication.ui.theme.Platinum
 @Composable
 fun NewsCardComponent(
     newsTitle: String,
-    newsSummary: String,
-    newsImageUrl: String,
+    newsSection: String,  // Section eklendi
+    newsAuthor: String?,  // Yazar bilgisi eklendi
+    imageUrl: String?,
     onClick: () -> Unit
 ) {
     Card(
@@ -40,52 +40,62 @@ fun NewsCardComponent(
             containerColor = Color.White
         )
     ) {
-        Column(
+        Row(
             modifier = Modifier
-                .padding(16.dp)
+                .padding(8.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically // Görsel ve metinler dikeyde ortalanacak
         ) {
-
-            // Görselin doğrudan yuvarlatılmış köşelerle ve sabit bir boyutta verilmesi
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(15.dp)) // Görselin kenarlarını yuvarlat
-                    .background(Color.White) // Görsel yüklenmediğinde arka plan rengi
-            ) {
+            // Sol taraftaki Görsel
+            if (imageUrl != null) {
                 Image(
-                    painter = rememberImagePainter(data = newsImageUrl),
-                    contentDescription = "News Image",
+                    painter = rememberImagePainter(data = imageUrl),
+                    contentDescription = null,
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(16 / 9f) // Görselin sabit en boy oranı (örneğin 16:9)
-                        .clip(RoundedCornerShape(15.dp)), // Görselin köşelerini yuvarlat
-                    // Görselin tamamen alanı doldurması için içerik ölçeklendirme ayarı
+                        .size(100.dp) // Görselin genişlik ve yüksekliği sabit
+                        .clip(RoundedCornerShape(10.dp)) // Görselin kenarları yuvarlanıyor
+                        .padding(end = 8.dp), // Görsel ile içerik arasında boşluk
                     contentScale = ContentScale.Crop
                 )
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.width(8.dp))
 
-            // Title with no maxLines limit
-            Text(
-                text = newsTitle,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = Color.Black,
+            // Sağ taraftaki Column: Section, Başlık ve Yazar bilgisi
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 8.dp)
-            )
+                    .fillMaxWidth() // Column'un tüm genişliği kaplaması için
+            ) {
+                // Section (Kategori)
+                Text(
+                    text = newsSection,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.LightGray, // Kategoriyi farklı bir renkle ayırabiliriz
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
 
-            // Summary (abstract) with maxLines = 2
-            Text(
-                text = newsSummary,
-                fontSize = 16.sp,
-                color = Color.DarkGray,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
-            )
+                // Başlık
+                Text(
+                    text = newsTitle,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.Black,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(bottom = 4.dp) // Alt boşluk
+                )
+
+                // Yazar bilgisi (Opsiyonel)
+                if (!newsAuthor.isNullOrEmpty()) {
+                    Text(
+                        text = "$newsAuthor",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Normal,
+                        color = Color.Gray
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/newsmobileapplication/ui/components/TopNewsScrollableRow.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/components/TopNewsScrollableRow.kt
@@ -1,0 +1,149 @@
+package com.example.newsmobileapplication.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberImagePainter
+import com.example.newsmobileapplication.model.entities.NewsItem
+import com.example.newsmobileapplication.ui.theme.Redwood
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Composable
+fun TopNewsScrollableRow(
+    topNewsItems: List<NewsItem>, // List of top news items
+    onNewsClick: (NewsItem) -> Unit
+) {
+    val listState = rememberLazyListState() // Kaydırma durumunu izlemek için LazyListState
+    val coroutineScope = rememberCoroutineScope()
+    var currentIndex by remember { mutableStateOf(0) } // Aktif indexi izlemek için
+    val density = LocalDensity.current // LocalDensity kullanarak dp to px dönüşümü
+
+    // Kart boyutları ve boşlukların px'e dönüştürülmesi
+    val itemWidthPx = with(density) { 300.dp.toPx() }
+    val itemSpacingPx = with(density) { 6.dp.toPx() }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        LazyRow(
+            state = listState,
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            items(topNewsItems) { newsItem ->
+                TopNewsCard(
+                    newsItem = newsItem,
+                    onClick = { onNewsClick(newsItem) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Göstergeler (dots)
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            repeat(topNewsItems.size) { index ->
+                Box(
+                    modifier = Modifier
+                        .padding(3.dp)
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(if (index == currentIndex) Color.Black else Color.LightGray)
+                        .clickable {
+                            coroutineScope.launch {
+                                listState.animateScrollToItem(index) // Dot tıklandığında o sıradaki habere geçiyoruz
+                            }
+                        }
+                )
+            }
+        }
+
+        // Kaydırma durumu izleniyor ve currentIndex güncelleniyor
+        LaunchedEffect(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset) {
+            val visibleItemIndex = listState.firstVisibleItemIndex
+            val visibleItemOffset = listState.firstVisibleItemScrollOffset.toFloat()
+            val totalItemWidth = itemWidthPx + itemSpacingPx
+            val offsetPercentage = visibleItemOffset / totalItemWidth
+
+            currentIndex = (visibleItemIndex + offsetPercentage.roundToInt()).coerceIn(0, topNewsItems.size - 1)
+        }
+    }
+}
+
+@Composable
+fun TopNewsCard(newsItem: NewsItem, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .size(300.dp) // Card boyutu ayarlanıyor
+            .padding(8.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(12.dp) // Köşeleri yuvarlatılmış card
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Haber görseli
+            if (newsItem.multimedia?.firstOrNull()?.url != null) {
+                Image(
+                    painter = rememberImagePainter(newsItem.multimedia.firstOrNull()?.url),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(RoundedCornerShape(12.dp)), // Köşeler yuvarlanıyor
+                    contentScale = ContentScale.Crop // Görselin kesilmesini önlemek için Crop
+                )
+            }
+            // Üst katman: Section ve Başlık
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.4f)) // Görsel üzerinde yarı saydam arka plan
+                    .padding(8.dp),
+                verticalArrangement = Arrangement.Bottom, // En alta yerleştiriyoruz
+                horizontalAlignment = Alignment.Start
+            ) {
+                // Section
+                Text(
+                    text = newsItem.section.uppercase(),
+                    fontSize = 12.sp,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier
+                        .background(Redwood, shape = RoundedCornerShape(4.dp))
+                        .padding(horizontal = 4.dp, vertical = 2.dp)
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Başlık
+                Text(
+                    text = newsItem.title,
+                    fontSize = 18.sp,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/newsmobileapplication/ui/screens/FeedScreen.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/ui/screens/FeedScreen.kt
@@ -1,10 +1,10 @@
 package com.example.newsmobileapplication.ui.screens
 
-
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -12,9 +12,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.example.newsmobileapplication.ui.components.NewsCardComponent
+import com.example.newsmobileapplication.ui.components.TopNewsScrollableRow
+import com.example.newsmobileapplication.ui.theme.Platinum
 import com.example.newsmobileapplication.utils.generateNewsItemId
 import com.example.newsmobileapplication.viewmodel.FeedViewModel
 
@@ -41,31 +45,73 @@ fun FeedScreen(navController: NavController, viewModel: FeedViewModel = hiltView
             CircularProgressIndicator()
         }
     } else {
-        // Show the list of news when loading is complete
-        LazyColumn {
-            if (newsItems != null) {
-                items(newsItems!!) { newsItem ->
-                    val newsItemId = generateNewsItemId(newsItem.url)
-                    val newsImageUrl = newsItem.multimedia?.firstOrNull()?.url ?: ""
+        // Show the feed content
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Breaking News (Top 5 News in a Scrollable Row)
+            Text(
+                text = "Breaking News",
+                fontSize = 24.sp,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                modifier = Modifier.padding(8.dp)
+            )
 
-                    NewsCardComponent(
-                        newsTitle = newsItem.title,
-                        newsSummary = newsItem.abstract ?: "No summary available",
-                        newsImageUrl = newsImageUrl,
-                        onClick = {
-                            navController.navigate("newsDetail/$newsItemId")
-                        }
-                    )
+            // Divider under Breaking News
+            Divider(
+                color = Platinum,
+                thickness = 1.dp,
+            )
+
+            if (newsItems != null && newsItems!!.isNotEmpty()) {
+                val topNewsItems = newsItems!!.take(5) // İlk 5 haberi alıyoruz
+
+                // Scrollable Row with Top 5 News
+                TopNewsScrollableRow(
+                    topNewsItems = topNewsItems,
+                    onNewsClick = { newsItem ->
+                        val newsItemId = generateNewsItemId(newsItem.url)
+                        navController.navigate("newsDetail/$newsItemId")
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Recommendation (Remaining News)
+                Text(
+                    text = "Recommendation",
+                    fontSize = 24.sp,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                    modifier = Modifier.padding(8.dp)
+                )
+
+                // Divider under Recommendation
+                Divider(
+                    color = Platinum,
+                    thickness = 1.dp,
+                )
+
+                LazyColumn {
+                    items(newsItems!!.drop(5)) { newsItem -> // 6. haberi başlat
+                        val newsItemId = generateNewsItemId(newsItem.url)
+                        val newsImageUrl = newsItem.multimedia?.firstOrNull()?.url ?: ""
+
+                        NewsCardComponent(
+                            newsTitle = newsItem.title,
+                            imageUrl = newsImageUrl,
+                            newsSection = newsItem.section,
+                            newsAuthor = newsItem.byline,
+                            onClick = {
+                                navController.navigate("newsDetail/$newsItemId")
+                            }
+                        )
+                    }
                 }
             } else {
                 // Show a friendly message when no news is available
-                item {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text("No news available.")
-                    }
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("No news available.")
                 }
             }
         }

--- a/app/src/main/java/com/example/newsmobileapplication/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/example/newsmobileapplication/viewmodel/FeedViewModel.kt
@@ -32,7 +32,7 @@ class FeedViewModel @Inject constructor(
     val errorMessage: StateFlow<String?> = _errorMessage
 
     init {
-        fetchTopStories("technology")  // Varsayılan olarak teknoloji haberleri çekiyoruz
+        fetchTopStories("home")  // Varsayılan olarak teknoloji haberleri çekiyoruz
         loadFavorites()  // Favori haberleri başlatma sırasında yükleyelim
     }
 


### PR DESCRIPTION
- Implemented a scrollable row for the top 5 'Breaking News' items on the feed screen.
- Each news card in the scrollable row shows an image, section, and title of the news.
- Added interactive indicator dots below the scrollable row to switch between news cards.
- Implemented a detailed news card layout for the 'Recommendations' section.
- Each news card in the recommendation list includes a thumbnail, section, title, and author information.
- Added dividers between the 'Breaking News' and 'Recommendations' sections for better visual separation.
- Integrated navigation to news details upon clicking a news card.